### PR TITLE
ci: add workflow to build docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,201 @@
+name: Build
+
+on:
+  pull_request:
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
+
+  push:
+    branches:
+      - main
+    paths:
+      - go.mod
+      - go.sum
+      - "**/*.go"
+      - Dockerfile
+      - .github/workflows/build.yml
+
+  merge_group:
+
+jobs:
+  build:
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
+
+    strategy:
+      matrix:
+        runner:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+
+    name: Build and push Docker image for ${{ matrix.runner }}
+
+    runs-on: ${{ matrix.runner }}
+
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Login to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Set Docker Buildx up
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
+
+      # No tags
+      - name: Build and push Docker image
+        id: build
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=image,"name=ghcr.io/grafana/flux-commit-tracker",push-by-digest=true,name-canonical=true
+          provenance: true
+          push: ${{ github.event_name == 'push' }}
+          sbom: false
+
+      - name: Export digests
+        if: github.event_name == 'push'
+        id: export-digests
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: |
+          # The digest of the _index_ - this is what we ultimately push, and
+          # what we need to refer to in the multi-arch manifest.
+          mkdir -pv "${RUNNER_TEMP}"/artifact/digests
+          touch "${RUNNER_TEMP}/artifact/digests/${DIGEST#sha256:}"
+
+          # The digest of the _manifest_ referred to by the index. When `docker
+          # buildx imagetools create` processes its inputs, it creates a new
+          # combines these manifest references into a new index. So we should
+          # attest this digest, then clients can find it given the multiarch
+          # index, by dereferencing to the per-arch manifests and looking at the
+          # referrers on them.
+          docker buildx imagetools inspect "ghcr.io/grafana/flux-commit-tracker@${DIGEST}" --raw | \
+            jq \
+              --raw-output \
+              '.manifests[] |
+              select (
+                .mediaType == "application/vnd.oci.image.manifest.v1+json" and .annotations["vnd.docker.reference.type"] == null
+                ) |
+              .digest' | \
+            ( echo -n 'digest=' && cat ) | \
+            tee -a "${GITHUB_OUTPUT}"
+
+      - name: Generate SBOM
+        if: github.event_name == 'push'
+        uses: anchore/sbom-action@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
+        with:
+          format: cyclonedx-json
+          image: ghcr.io/grafana/flux-commit-tracker@${{ steps.export-digests.outputs.digest }}
+          output-file: ${{ runner.temp }}/sbom-${{ matrix.runner }}.json
+
+      - name: Generate SBOM attestation
+        if: github.event_name == 'push'
+        uses: actions/attest-sbom@115c3be05ff3974bcbd596578934b3f9ce39bf68 # v2.2.0
+        with:
+          push-to-registry: true
+          subject-digest: ${{ steps.export-digests.outputs.digest }}
+          subject-name: ghcr.io/grafana/flux-commit-tracker
+          sbom-path: ${{ runner.temp }}/sbom-${{ matrix.runner }}.json
+
+      - name: Upload artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: artifacts-${{ matrix.runner }}
+          path: ${{ runner.temp }}/artifact/
+          if-no-files-found: error
+          retention-days: 1
+
+  manifest:
+    if: github.event_name == 'push'
+
+    needs:
+      - build
+
+    permissions:
+      attestations: write
+      id-token: write
+      packages: write
+
+    name: Generate multi-arch manifest list and build provenance attestation
+
+    runs-on: ubuntu-24.04
+
+    outputs:
+      digest: ${{ steps.inspect.outputs.digest }}
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          merge-multiple: true
+          path: ${{ runner.temp }}/artifacts
+          pattern: artifacts-*
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
+        with:
+          images: ghcr.io/grafana/flux-commit-tracker
+          sep-tags: ' '
+          tags: |
+            # tag with branch name for `main`
+            type=ref,event=branch,enable={{is_default_branch}}
+            # tag with semver, and `latest`
+            type=ref,event=tag
+            # for testing
+            type=ref,event=branch
+
+      - name: Login to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/artifacts/digests
+        run: |
+          # We want word splitting here to give separate args to `docker buildx imagetools create`.
+          # shellcheck disable=SC2046
+          docker buildx imagetools create $(jq --compact-output --raw-output '.tags | map("-t " + .) | join(" ")' <<< "${DOCKER_METADATA_OUTPUT_JSON}") \
+            $(printf 'ghcr.io/grafana/flux-commit-tracker@sha256:%s ' *)
+
+      - name: Inspect image
+        id: inspect
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+            docker buildx imagetools inspect "ghcr.io/grafana/flux-commit-tracker:${VERSION}"
+
+            # Output image digest as github output
+            docker buildx imagetools inspect "ghcr.io/grafana/flux-commit-tracker:${VERSION}" --format "{{json .Manifest.Digest}}" | \
+              xargs | \
+              ( echo -n 'digest=' && cat ) | \
+              tee -a "${GITHUB_OUTPUT}"
+
+      - name: Generate build provenance attestation
+        uses: actions/attest-build-provenance@520d128f165991a6c774bcb264f323e3d70747f4 # v2.2.0
+        with:
+          push-to-registry: true
+          subject-name: ghcr.io/grafana/flux-commit-tracker
+          subject-digest: ${{ steps.inspect.outputs.digest }}


### PR DESCRIPTION
Build a multi-arch docker image for amd64 and arm64 using Actions and pushing to GHCR. Attested and all the good stuff.

Instructions also added to the README.
