### PR TITLE
ci: add testing/linting workflow

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -1,0 +1,99 @@
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+
+  merge_group:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
+
+      - name: Run tests
+        run: |
+          go test -v ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Lint markdown
+        uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265 # v19.1.0
+        with:
+          config: .markdownlint.yaml
+
+      - name: Get actionlint release
+        id: get-actionlint-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          eval "$(gh api \
+            /repos/rhysd/actionlint/releases/latest \
+            --jq '.assets[] |
+              select (.name | endswith("_linux_amd64.tar.gz")) |
+              "node_id=\(.node_id | @sh); browser_download_url=\(.browser_download_url | @sh)"')"
+
+          echo "node_id=${node_id}" | tee -a "${GITHUB_OUTPUT}"
+          echo "browser_download_url=${browser_download_url}" | tee -a "${GITHUB_OUTPUT}"
+
+          mkdir -p ~/.local/bin
+          echo "${HOME}/.local/bin" | tee -a "${GITHUB_PATH}"
+
+      - name: Cache actionlint
+        id: cache-actionlint
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.local/bin/actionlint
+          key: actionlint-${{ steps.get-actionlint-release.outputs.node_id }}
+
+      - name: Download actionlint
+        id: get_actionlint
+        if: steps.cache-actionlint.outputs.cache-hit != 'true'
+        env:
+          RELEASE: ${{ steps.get-actionlint-release.outputs.browser_download_url }}
+        run: |
+          curl -sSL "${RELEASE}" \
+            | tar -C ~/.local/bin/ -xzf - actionlint
+
+          chmod +x ~/.local/bin/actionlint
+
+      - name: Check workflow files
+        run: actionlint -color
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+
+      - name: Run zizmor
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: uvx zizmor --format sarif . > results.sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.3
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/internal/github/github_tracing_test.go
+++ b/internal/github/github_tracing_test.go
@@ -60,7 +60,7 @@ func TestTraceInstrumentation(t *testing.T) {
 
 	span.End()
 
-	getFileSpan := testTel.FindSpan(ctx, "github.get_file")
+	getFileSpan := testTel.FindSpan(t, ctx, "github.get_file")
 	require.NotNil(t, getFileSpan, "Could not find the 'github.get_file' span")
 
 	expectedAttrs := []attribute.KeyValue{
@@ -97,7 +97,7 @@ func TestTraceInstrumentationWithError(t *testing.T) {
 	repoNotFoundError := RepositoryNotFoundError{}
 	require.ErrorAs(t, err, &repoNotFoundError)
 
-	getFileSpan := testTel.FindSpan(ctx, "github.get_file")
+	getFileSpan := testTel.FindSpan(t, ctx, "github.get_file")
 	require.NotNil(t, getFileSpan, "Could not find the 'github.get_file' span")
 
 	otel.AssertSpanStatus(t, getFileSpan, codes.Error)

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -55,7 +55,7 @@ func (w *SlogWriter) Write(p []byte) (n int, err error) {
 		Message: string(p),
 	}
 
-	if err := w.Handler.Handle(w.context, record); err != nil {
+	if err := w.Handle(w.context, record); err != nil {
 		return 0, fmt.Errorf("failed to write log: %w", err)
 	}
 

--- a/internal/otel/oteltest.go
+++ b/internal/otel/oteltest.go
@@ -143,10 +143,13 @@ func (t *TestTelemetry) SpansByName(name string) []sdktrace.ReadOnlySpan {
 }
 
 // FindSpan returns the first span with the given name, or nil if not found
-func (t *TestTelemetry) FindSpan(ctx context.Context, name string) sdktrace.ReadOnlySpan {
-	t.TraceProcessor.ForceFlush(ctx)
+func (tt *TestTelemetry) FindSpan(t *testing.T, ctx context.Context, name string) sdktrace.ReadOnlySpan {
+	t.Helper()
 
-	spans := t.TraceExporter.GetSpans()
+	err := tt.TraceProcessor.ForceFlush(ctx)
+	require.NoError(t, err)
+
+	spans := tt.TraceExporter.GetSpans()
 	if len(spans) == 0 {
 		return nil
 	}


### PR DESCRIPTION
Runs `golangci-lint`, `markdownlint`, `actionlint`, `zizmor` and the testsuite.
