### PR TITLE
feat(otel): use exponential histogram, add build info and standard otel resources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,21 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
 
     steps:
+      - name: Calculate build variables
+        id: calculate-build-variables
+        run: |
+          # Version is hardcoded for now to 0.0.0
+          echo "version=0.0.0" | tee -a "${GITHUB_OUTPUT}"
+
+          # Fetch the commit and branch from the event
+          echo "commit=${GITHUB_SHA}" | tee -a "${GITHUB_OUTPUT}"
+
+          BRANCH="unknown"
+          if [ "${GITHUB_REF_TYPE}" = "branch" ]; then
+            BRANCH="${GITHUB_REF_NAME}"
+          fi
+          echo "branch=${BRANCH}" | tee -a "${GITHUB_OUTPUT}"
+
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -63,6 +78,10 @@ jobs:
         id: build
         uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
         with:
+          build-args: |
+            VERSION=${{ steps.calculate-build-variables.outputs.version }}
+            COMMIT=${{ steps.calculate-build-variables.outputs.commit }}
+            BRANCH=${{ steps.calculate-build-variables.outputs.branch }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=image,"name=ghcr.io/grafana/flux-commit-tracker",push-by-digest=true,name-canonical=true
@@ -156,7 +175,7 @@ jobs:
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ghcr.io/grafana/flux-commit-tracker
-          sep-tags: ' '
+          sep-tags: " "
           tags: |
             # tag with branch name for `main`
             type=ref,event=branch,enable={{is_default_branch}}
@@ -185,13 +204,13 @@ jobs:
         env:
           VERSION: ${{ steps.meta.outputs.version }}
         run: |
-            docker buildx imagetools inspect "ghcr.io/grafana/flux-commit-tracker:${VERSION}"
+          docker buildx imagetools inspect "ghcr.io/grafana/flux-commit-tracker:${VERSION}"
 
-            # Output image digest as github output
-            docker buildx imagetools inspect "ghcr.io/grafana/flux-commit-tracker:${VERSION}" --format "{{json .Manifest.Digest}}" | \
-              xargs | \
-              ( echo -n 'digest=' && cat ) | \
-              tee -a "${GITHUB_OUTPUT}"
+          # Output image digest as github output
+          docker buildx imagetools inspect "ghcr.io/grafana/flux-commit-tracker:${VERSION}" --format "{{json .Manifest.Digest}}" | \
+            xargs | \
+            ( echo -n 'digest=' && cat ) | \
+            tee -a "${GITHUB_OUTPUT}"
 
       - name: Generate build provenance attestation
         uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,19 @@ WORKDIR /app
 
 ARG TARGETOS TARGETARCH
 
+ARG VERSION=unknown
+ARG COMMIT=unknown
+ARG BRANCH=unknown
+
 RUN --mount=target=. \
-    --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
-    GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOAMD64=v2 \
-    go build \
-      -trimpath \
-      -ldflags="-s -w" \
-      -o /usr/bin/flux-commit-tracker \
-      ./cmd/main.go
+  --mount=type=cache,target=/root/.cache/go-build \
+  --mount=type=cache,target=/go/pkg/mod \
+  GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOAMD64=v2 \
+  go build \
+  -trimpath \
+  -ldflags="-s -w -X github.com/grafana/flux-commit-tracker/internal/buildinfo.Version=${VERSION} -X github.com/grafana/flux-commit-tracker/internal/buildinfo.Commit=${COMMIT} -X github.com/grafana/flux-commit-tracker/internal/buildinfo.Branch=${BRANCH}" \
+  -o /usr/bin/flux-commit-tracker \
+  ./cmd/main.go
 
 FROM scratch
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,10 +38,8 @@ const (
 	FallbackNamespace = "default"
 )
 
-var (
-	// k8s controller
-	scheme = runtime.NewScheme()
-)
+// k8s controller
+var scheme = runtime.NewScheme()
 
 func init() {
 	// k8s controller initialisation
@@ -128,13 +126,11 @@ func (cli CLI) run(handler slog.Handler) error {
 	ctx := ctrl.SetupSignalHandler()
 
 	otelConfig := internalotel.Config{
-		ServiceName:      tracker.OtelName,
-		ServiceNamespace: tracker.OtelNamespace,
-		Mode:             cli.Telemetry.Mode,
-		OTLPEndpoint:     cli.Telemetry.Endpoint,
-		UseInsecure:      cli.Telemetry.Insecure,
-		BatchTimeout:     1 * time.Second,
-		MetricInterval:   15 * time.Second,
+		Mode:           cli.Telemetry.Mode,
+		OTLPEndpoint:   cli.Telemetry.Endpoint,
+		UseInsecure:    cli.Telemetry.Insecure,
+		BatchTimeout:   1 * time.Second,
+		MetricInterval: 15 * time.Second,
 	}
 
 	configuredSlogLogger, otelShutdown, err := internalotel.SetupTelemetry(ctx, otelConfig, handler)

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,8 @@
+package buildinfo
+
+// Overridden at build time
+var (
+	Version = "unknown"
+	Commit  = "unknown"
+	Branch  = "unknown"
+)

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -24,10 +24,10 @@ import (
 )
 
 const (
-	OtelName = "github.com/grafana/flux-commit-tracker/internal/github"
+	InstrumentationScope = "github"
 )
 
-var tracer = otel.Tracer(OtelName)
+var tracer = otel.Tracer(InstrumentationScope)
 
 // Client defines the interface for interacting with GitHub.
 type Client interface {


### PR DESCRIPTION
The fixed buckets of the explicit histograms we use currently make monitoring the variable durations of our CI runs a bit tricky. Fortunately, OpenTelemetry has another kind of histogram called an [Exponential Histogram], which can offer better resolution and dynamically adjusts to changing data (up to a configured maximum size), such as if we improve/regress performance or if the data is different in quiet periods.

These are represented in Prometheus/Mimir as [Native Histograms].

It can be bit confusing to understand - here's some further reading
[0] [1] [2].

We also add build info which we set in CI, and will be able to use during our CD workflow, and some standard Otel resources/labels.

[Exponential Histogram]: https://opentelemetry.io/docs/specs/otel/metrics/data-model/
[Native Histograms]: https://prometheus.io/docs/specs/native_histograms/
[0]: https://dyladan.me/histograms/2023/05/04/exponential-histograms/
[1]: https://newrelic.com/blog/best-practices/opentelemetry-histograms
[2]: https://grafana.com/docs/mimir/latest/send/otel-exponential-histograms/
