### PR TITLE
fix(Dockerfile): make sure we run as a user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,16 @@ RUN --mount=target=. \
 
 FROM scratch
 
+COPY <<EOF /etc/group
+nogroup:x:65534:
+EOF
+
+COPY <<EOF /etc/passwd
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+EOF
+
+USER nobody:nogroup
+
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /usr/bin/flux-commit-tracker /usr/bin/flux-commit-tracker
 


### PR DESCRIPTION
When we start the current code from the container build, we're getting

```console
Error: unable to set up OpenTelemetry SDK: failed to create initial resources: error detecting resource: user: Current requires cgo or $USER set in environment
```

This is because, in commit 09b72e075c8df7e29af4b1efa64680f57a574272, we added `resource.WithProcess()` to include process information in the exported resources. One of the fields this looks up is the username of the process's UID. Since we are using a `scratch` image, unless we put them there there are no users or groups present. The `os/user` package errors with the message above if it can't find the user.

The minimal fix we're doing here is to create a user and a group for us to run as, so that this lookup succeeds inside the container.
