### PR TITLE
chore: disable pin and digest updatetypes for docker-compose

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -47,7 +47,10 @@
     // only and are updated too frequently:
     {
       "matchFileNames": [
-        "docker-compose.yml"
+        "docker-compose.yml",
+      ],
+      "matchDataSources": [
+        "docker",
       ],
       "matchUpdateTypes": [
         "pinDigest",


### PR DESCRIPTION
Only disabling pinDigest seems not have been enough. Perhaps this will help.