### PR TITLE
feat(ci): trigger release-cd deployments from main builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -322,7 +322,7 @@ jobs:
 
           echo "contextMessage= This deployment was triggered by [this pull request](https://github.com/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/pull/${PR})." >> "${GITHUB_OUTPUT}"
           echo "number=${PR}" >> "${GITHUB_OUTPUT}"
-          TS=$(date -u --date ${FIRST_COMMIT_TS} +'%s')
+          TS=$(date -u --date "${FIRST_COMMIT_TS}" +'%s')
           echo "first-commit-ts=${TS}" >> "${GITHUB_OUTPUT}"
           cat "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
 
     outputs:
       digest: ${{ steps.build.outputs.digest }}
+      version: ${{ steps.calculate-build-variables.outputs.version }}
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -211,6 +212,7 @@ jobs:
           images: ghcr.io/grafana/flux-commit-tracker
           sep-tags: " "
           tags: |
+            type=raw,value=${{ needs.build.outputs.version }}
             # tag with branch name for `main`
             type=ref,event=branch,enable={{is_default_branch}}
             # tag with semver, and `latest`
@@ -236,7 +238,7 @@ jobs:
       - name: Inspect image
         id: inspect
         env:
-          VERSION: ${{ steps.meta.outputs.version }}
+          VERSION: ${{ needs.build.outputs.version }}
         run: |
           docker buildx imagetools inspect "ghcr.io/grafana/flux-commit-tracker:${VERSION}"
 
@@ -252,3 +254,84 @@ jobs:
           push-to-registry: true
           subject-name: ghcr.io/grafana/flux-commit-tracker
           subject-digest: ${{ steps.inspect.outputs.digest }}
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+    needs:
+      - build
+      - manifest
+
+    steps:
+      - id: find-commit-pr
+        uses: octokit/graphql-action@ddde8ebb2493e79f390e6449c725c21663a67505 # v3.0.2
+        name: Find PR for commit
+        with:
+          query: |
+            query associatedPRs($sha: String, $repo: String!, $owner: String!) {
+              repository(name: $repo, owner: $owner) {
+                object(expression: $sha) {
+                ... on Commit {
+                    associatedPullRequests(first: 5) {
+                      edges {
+                        node {
+                          number
+                          commits(first: 1) {
+                            edges {
+                              node {
+                                commit {
+                                  committedDate
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          variables: |
+            owner: ${{ github.repository_owner }}
+            repo: ${{ github.event.repository.name }}
+            sha: ${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: extract-pr-number
+        name: Extract PR number
+        env:
+          PR: ${{ fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.number }}
+          FIRST_COMMIT_TS: ${{ fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.commits.edges[0].node.commit.committedDate }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
+        run: |
+          if [ -z "${PR}" ]; then
+            echo "No PR found, skipping..."
+            echo "contextMessage=\"\"" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          echo "This commit was from PR ${PR}"
+
+          echo "contextMessage= This deployment was triggered by [this pull request](https://github.com/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/pull/${PR})." >> "${GITHUB_OUTPUT}"
+          echo "number=${PR}" >> "${GITHUB_OUTPUT}"
+          TS=$(date -u --date ${FIRST_COMMIT_TS} +'%s')
+          echo "first-commit-ts=${TS}" >> "${GITHUB_OUTPUT}"
+          cat "${GITHUB_OUTPUT}"
+
+      - id: submit-argowfs-deployment
+        name: Submit Argo Workflows deployment
+        uses: grafana/shared-workflows/actions/trigger-argo-workflow@ecdca383418cd7662e5e96f6297c72c98d52916f # trigger-argo-workflows/v1.1.1
+        with:
+          namespace: release-cd
+          workflow_template: flux-commit-tracker
+          parameters: |
+            dockertag=${{ needs.build.outputs.version }}
+            prCommentContext=${{ steps.extract-pr-number.outputs.contextMessage }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,7 +258,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+    if: ${{ github.event_name == 'push' && github.ref_name == 'main' && github.repository == 'grafana/flux-commit-tracker' }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
This PR adds the ability to trigger `release-cd/flux-commit-tracker` automatically after successful `main` image builds.

### Changes

- publish the generated build version as an immutable image tag in GHCR
- add a deploy job that triggers the `flux-commit-tracker` Argo workflow in `release-cd`
- include `prCommentContext` so the generated deployment PR links back to the source PR