### PR TITLE
fix(deploy-workflow): resolve rollout owner from merged pr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,6 +281,12 @@ jobs:
                       edges {
                         node {
                           number
+                          author {
+                            login
+                          }
+                          mergedBy {
+                            login
+                          }
                           commits(first: 1) {
                             edges {
                               node {
@@ -304,10 +310,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: extract-pr-number
-        name: Extract PR number
+      - id: extract-pr-metadata
+        name: Extract PR metadata
         env:
           PR: ${{ fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.number }}
+          PR_AUTHOR: ${{ fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.author.login }}
+          PR_MERGED_BY: ${{ fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.mergedBy.login }}
           FIRST_COMMIT_TS: ${{ fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.commits.edges[0].node.commit.committedDate }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           REPOSITORY_NAME: ${{ github.event.repository.name }}
@@ -319,6 +327,13 @@ jobs:
           fi
 
           echo "This commit was from PR ${PR}"
+
+          ROLLOUT_OWNER="${PR_MERGED_BY:-${PR_AUTHOR}}"
+          ROLLOUT_OWNER="$(printf '%s' "${ROLLOUT_OWNER}" | tr -cd 'A-Za-z0-9_.-')"
+          if [ -n "${ROLLOUT_OWNER}" ]; then
+            echo "Using ${ROLLOUT_OWNER} as the rollout owner"
+            echo "extra_args=--labels trigger-commit-author=${ROLLOUT_OWNER}" >> "${GITHUB_OUTPUT}"
+          fi
 
           echo "contextMessage= This deployment was triggered by [this pull request](https://github.com/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/pull/${PR})." >> "${GITHUB_OUTPUT}"
           echo "number=${PR}" >> "${GITHUB_OUTPUT}"
@@ -332,6 +347,7 @@ jobs:
         with:
           namespace: release-cd
           workflow_template: flux-commit-tracker
+          extra_args: ${{ steps.extract-pr-metadata.outputs.extra_args }}
           parameters: |
             dockertag=${{ needs.build.outputs.version }}
-            prCommentContext=${{ steps.extract-pr-number.outputs.contextMessage }}
+            prCommentContext=${{ steps.extract-pr-metadata.outputs.contextMessage }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -324,11 +324,9 @@ jobs:
 
           echo "This commit was from PR ${PR}"
 
-          ROLLOUT_OWNER="${PR_MERGED_BY}"
-          ROLLOUT_OWNER="$(printf '%s' "${ROLLOUT_OWNER}" | tr -cd 'A-Za-z0-9_.-')"
-          if [ -n "${ROLLOUT_OWNER}" ]; then
-            echo "Using ${ROLLOUT_OWNER} as the rollout owner"
-            echo "extra_args=--labels trigger-commit-author=${ROLLOUT_OWNER}" >> "${GITHUB_OUTPUT}"
+          if [ -n "${PR_MERGED_BY}" ]; then
+            echo "Using ${PR_MERGED_BY} as the rollout owner"
+            echo "extra_args=--labels trigger-commit-author=${PR_MERGED_BY}" >> "${GITHUB_OUTPUT}"
           fi
 
           echo "contextMessage= This deployment was triggered by [this pull request](https://github.com/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/pull/${PR})." >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,9 +281,6 @@ jobs:
                       edges {
                         node {
                           number
-                          author {
-                            login
-                          }
                           mergedBy {
                             login
                           }
@@ -314,7 +311,6 @@ jobs:
         name: Extract PR metadata
         env:
           PR: ${{ fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.number }}
-          PR_AUTHOR: ${{ fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.author.login }}
           PR_MERGED_BY: ${{ fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.mergedBy.login }}
           FIRST_COMMIT_TS: ${{ fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.commits.edges[0].node.commit.committedDate }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}
@@ -328,7 +324,7 @@ jobs:
 
           echo "This commit was from PR ${PR}"
 
-          ROLLOUT_OWNER="${PR_MERGED_BY:-${PR_AUTHOR}}"
+          ROLLOUT_OWNER="${PR_MERGED_BY}"
           ROLLOUT_OWNER="$(printf '%s' "${ROLLOUT_OWNER}" | tr -cd 'A-Za-z0-9_.-')"
           if [ -n "${ROLLOUT_OWNER}" ]; then
             echo "Using ${ROLLOUT_OWNER} as the rollout owner"


### PR DESCRIPTION
This PR resolves the Argo rollout owner from the associated pull request metadata so merge queue pushes do not attribute deployments to the merge queue bot. When the attribution is left with the bot, it causes errors in the Argo rollout.

## Changes

- Get the associated PR author and merger in the deploy workflow GraphQL query
- Use the PR merger as the rollout owner
- Use `extra_args` to override Argo’s `trigger-commit-author` label with the PR merger