### PR TITLE
test(signed-commits): add signed-commits test workflow to test forked PRs

### DIFF
--- a/.github/workflows/signed-commits-test.yml
+++ b/.github/workflows/signed-commits-test.yml
@@ -1,0 +1,14 @@
+name: Signed commits info
+
+on:
+  pull_request:
+
+jobs:
+  signed-commits:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: grafana/signed-commits-info-action@5d082f6aeba630074da618ce4f672f3dfed16e95


### PR DESCRIPTION
This PR adds a temporary workflow to test `grafana/signed-commits-info-action` on forked pull requests.

## Why

We need to verify whether the current `pull_request`-based workflow can leave comments on PRs opened from forks, or whether fork token restrictions will require `pull_request_target`.

## Test Plan

After this merges, I'll open a draft PR from a personal fork with an unsigned commit and confirm whether the workflow can detect the unsigned commit and post the PR comment.